### PR TITLE
script for setting the env var for development

### DIFF
--- a/set_open3d_ml_root.sh
+++ b/set_open3d_ml_root.sh
@@ -1,0 +1,8 @@
+# Sets the env var OPEN3D_ML_ROOT to the directory of this file.
+# The open3d package will use this var to integrate ml3d into a common namespace.
+export OPEN3D_ML_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+if [[ $0 == $BASH_SOURCE ]]; then 
+        echo "source this script to set the OPEN3D_ML_ROOT env var."     
+else
+        echo "OPEN3D_ML_ROOT is now $OPEN3D_ML_ROOT"
+fi


### PR DESCRIPTION
This PR adds a script for setting the OPEN3D_ML_ROOT env variable for testing the integration with the main open3d package.