### PR TITLE
added Makefile and set execute flag for compile_op.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+all:
+	./compile_op.sh

--- a/compile_op.sh
+++ b/compile_op.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 cd utils/nearest_neighbors
 python setup.py install --home="."
 cd ../../


### PR DESCRIPTION
This PR adds a Makefile to compile the ops. The makefile will be called from the build system of the main open3d repo when building a wheel.