### PR TITLE
Undefined name: remap_lut --> self.remap_lut

### DIFF
--- a/ml3d/datasets/semantickitti.py
+++ b/ml3d/datasets/semantickitti.py
@@ -213,7 +213,7 @@ class SemanticKITTI(BaseDataset):
 
             store_path = join(save_path, name_points + '.label')
             pred = pred + 1
-            pred = remap_lut[pred].astype(np.uint32)
+            pred = self.remap_lut[pred].astype(np.uint32)
             pred.tofile(store_path)
 
     def get_split_list(self, split):


### PR DESCRIPTION
`self.remap_lut` is defined on line 102 and used in a similar way on line 193.

$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./ml3d/datasets/semantickitti.py:216:20: F821 undefined name 'remap_lut'
            pred = remap_lut[pred].astype(np.uint32)
                   ^
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/336)
<!-- Reviewable:end -->
