### PR TITLE
Undefined name: val_files --> self.val_files

### DIFF
--- a/ml3d/datasets/waymo.py
+++ b/ml3d/datasets/waymo.py
@@ -207,7 +207,7 @@ class Waymo(BaseDataset):
         elif split in ['test', 'testing']:
             return self.test_files
         elif split in ['val', 'validation']:
-            return val_files
+            return self.val_files
         elif split in ['all']:
             return self.train_files + self.val_files + self.test_files
         else:


### PR DESCRIPTION
`self.val_files` is created on line 63 and set on line 71 and printed on line 212

$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./ml3d/datasets/waymo.py:210:20: F821 undefined name 'val_files'
            return val_files
                   ^
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/337)
<!-- Reviewable:end -->
