### PR TITLE
Added missing `sum()` call to `loss_cls`

### DIFF
--- a/ml3d/torch/models/point_pillars.py
+++ b/ml3d/torch/models/point_pillars.py
@@ -195,6 +195,7 @@ class PointPillars(BaseModel):
                                        target_bboxes,
                                        avg_factor=avg_factor)
         else:
+            loss_cls = loss_cls.sum()
             loss_bbox = bboxes.sum()
             loss_dir = dirs.sum()
 


### PR DESCRIPTION
Fixes error in validation loop of the `object_detection.py` pipeline caused by loss being arbitrary size rather than scalar value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/343)
<!-- Reviewable:end -->
