### PR TITLE
Make focal loss always zero for single class classification problem

### DIFF
--- a/ml3d/torch/modules/losses/focal_loss.py
+++ b/ml3d/torch/modules/losses/focal_loss.py
@@ -29,11 +29,8 @@ class FocalLoss(nn.Module):
         self.loss_weight = loss_weight
 
     def forward(self, pred, target, weight=None, avg_factor=None):
-
         pred_sigmoid = pred.sigmoid()
-
-        if len(pred.shape) > 1 and int(pred.shape[-1]) > 1:
-            target = one_hot(target, int(pred.shape[-1]))
+        target = one_hot(target, int(pred.shape[-1]))
         target = target.type_as(pred)
 
         pt = (1 - pred_sigmoid) * target + pred_sigmoid * (1 - target)


### PR DESCRIPTION
Without this check, when running with a single class the code will try to allocate a very large array on the GPU and fail with the following error:

```
Traceback (most recent call last):
  File "scripts/run_pipeline.py", line 147, in <module>
    main()
  File "scripts/run_pipeline.py", line 143, in main
    pipeline.run_train()
  File "/home/k/code/Open3D-ML/ml3d/torch/pipelines/object_detection.py", line 296, in run_train
    loss = model.loss(results, data)
  File "/home/k/code/Open3D-ML/ml3d/torch/models/point_pillars.py", line 164, in loss
    avg_factor=avg_factor)
  File "/home/k/miniconda3/envs/o3donly/lib/python3.6/site-packages/torch/nn/modules/module.py", line 727, in _call_impl
    result = self.forward(*input, **kwargs)
  File "/home/k/code/Open3D-ML/ml3d/torch/modules/losses/focal_loss.py", line 40, in forward
    pt = (1 - pred_sigmoid) * target + pred_sigmoid * (1 - target)
RuntimeError: CUDA out of memory. Tried to allocate 1535.09 GiB (GPU 0; 10.75 GiB total capacity; 3.99 GiB already allocated; 4.64 GiB free; 4.03 GiB reserved in total by PyTorch)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/344)
<!-- Reviewable:end -->
