### PR TITLE
Fixed a bug in semantickitti.py / save_test_result().

### DIFF
--- a/ml3d/datasets/semantickitti.py
+++ b/ml3d/datasets/semantickitti.py
@@ -177,6 +177,7 @@ class SemanticKITTI(BaseDataset):
             attr: The attributes that correspond to the outputs passed in results.
         """
         cfg = self.cfg
+        pred = results['predict_labels']
         name = attr['name']
         name_seq, name_points = name.split("_")
 


### PR DESCRIPTION
When testing model (e.g. RandLANet) on Semantic KITTI dataset, I got an error:

```
 Traceback (most recent call last):
  File "scripts/run_pipeline.py", line 145, in <module>
    main()
  File "scripts/run_pipeline.py", line 139, in main
    pipeline.run_test()
  File "/usr/local/lib/python3.6/dist-packages/open3d/_ml3d/torch/pipelines/semantic_segmentation.py", line 241, in run_test
    dataset.save_test_result(inference_result, attr)
  File "/usr/local/lib/python3.6/dist-packages/open3d/_ml3d/datasets/semantickitti.py", line 189, in save_test_result
    pred[pred >= ign] += 1
UnboundLocalError: local variable 'pred' referenced before assignment
```

This seems to be a small bug in function `save_test_result()` in `ml3d/datasets/semantickitti.py`. After comparing with how this function is implemented in other datasets, I added a line that fixes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/352)
<!-- Reviewable:end -->
