### PR TITLE
Add NuScenes lidar semantic segmentation support

### DIFF
--- a/ml3d/configs/randlanet_nuscenes.yml
+++ b/ml3d/configs/randlanet_nuscenes.yml
@@ -1,0 +1,56 @@
+dataset:
+  name: NuScenes
+  dataset_path: # path/to/your/dataset
+  cache_dir: ./logs/cache
+  class_weights: [2061156, 5385, 2156470, 9655, 139443, 8723, 9159, 8809, 12168,
+  9305106, 66861, 718641, 736239, 163126, 141351, 357463, 4247297, 38104219,
+  1514414, 2218, 59590, 427391, 4907511, 15841384, 316958899, 8559216, 70197461,
+  70289730, 178178063, 817150, 122581273, 337070621]
+  ignored_label_inds: []
+  #num_points: 40960
+  #test_area_idx: 3
+  test_result_folder: ./test
+  use_cache: False
+  #sampler:
+  #  name: 'SemSegRandomSampler'
+model:
+  name: RandLANet
+  batcher: DefaultBatcher
+  ckpt_path: # path/to/your/checkpoint
+  dim_feature: 8
+  dim_input: 3
+  dim_output:
+  - 16
+  - 64
+  - 128
+  - 256
+  - 512
+  grid_size: 0.04
+  ignored_label_inds: []
+  k_n: 16
+  num_classes: 32
+  num_layers: 5
+  num_points: 40960
+  sub_sampling_ratio:
+  - 4
+  - 4
+  - 4
+  - 4
+  - 2
+  t_normalize:
+    method: linear
+    normalize_points: False
+    feat_bias: 0
+    feat_scale: 1
+pipeline:
+  name: SemanticSegmentation
+  adam_lr: 0.01
+  batch_size: 2
+  learning_rate: 0.01
+  main_log_dir: ./logs
+  max_epoch: 100
+  save_ckpt_freq: 20
+  scheduler_gamma: 0.95
+  test_batch_size: 3
+  train_sum_dir: train_log
+  val_batch_size: 2

--- a/ml3d/datasets/nuscenes.py
+++ b/ml3d/datasets/nuscenes.py
@@ -96,7 +96,6 @@ class NuScenes(BaseDataset):
         Returns:
             A mapping from the class names to the respective RGB values.
         """
-
         classname_to_color = {  # RGB.
             "noise": (0, 0, 0),  # Black.
             "animal": (70, 130, 180),  # Steelblue

--- a/ml3d/datasets/nuscenes.py
+++ b/ml3d/datasets/nuscenes.py
@@ -11,8 +11,6 @@ from .base_dataset import BaseDataset, BaseDatasetSplit
 from ..utils import Config, make_dir, DATASET
 from .utils import BEVBox3D
 
-from nuscenes.utils.color_map import get_colormap
-
 logging.basicConfig(
     level=logging.INFO,
     format='%(levelname)s - %(asctime)s - %(module)s - %(message)s',
@@ -63,7 +61,7 @@ class NuScenes(BaseDataset):
         self.label_to_names = self.get_label_to_names()
         self.num_classes = len(self.label_to_names)
         # Initialize the colormap which maps from class names to RGB values.
-        self.color_map = get_colormap()
+        self.color_map = self.get_colormap()
         assert len(self.color_map) == self.num_classes
         if isinstance(list(self.color_map.values())[0], tuple):
             self.color_map = dict([
@@ -89,6 +87,54 @@ class NuScenes(BaseDataset):
         if os.path.exists(join(info_path, 'infos_test.pkl')):
             self.test_info = pickle.load(
                 open(join(info_path, 'infos_test.pkl'), 'rb'))
+
+    @staticmethod
+    def get_colormap():
+        """Get the defined colormap.
+        source: https://github.com/nutonomy/nuscenes-devkit/blob/master/python-sdk/nuscenes/utils/color_map.py
+        
+        Returns:
+            A mapping from the class names to the respective RGB values.
+        """
+
+        classname_to_color = {  # RGB.
+            "noise": (0, 0, 0),  # Black.
+            "animal": (70, 130, 180),  # Steelblue
+            "human.pedestrian.adult": (0, 0, 230),  # Blue
+            "human.pedestrian.child": (135, 206, 235),  # Skyblue,
+            "human.pedestrian.construction_worker":
+                (100, 149, 237),  # Cornflowerblue
+            "human.pedestrian.personal_mobility":
+                (219, 112, 147),  # Palevioletred
+            "human.pedestrian.police_officer": (0, 0, 128),  # Navy,
+            "human.pedestrian.stroller": (240, 128, 128),  # Lightcoral
+            "human.pedestrian.wheelchair": (138, 43, 226),  # Blueviolet
+            "movable_object.barrier": (112, 128, 144),  # Slategrey
+            "movable_object.debris": (210, 105, 30),  # Chocolate
+            "movable_object.pushable_pullable": (105, 105, 105),  # Dimgrey
+            "movable_object.trafficcone": (47, 79, 79),  # Darkslategrey
+            "static_object.bicycle_rack": (188, 143, 143),  # Rosybrown
+            "vehicle.bicycle": (220, 20, 60),  # Crimson
+            "vehicle.bus.bendy": (255, 127, 80),  # Coral
+            "vehicle.bus.rigid": (255, 69, 0),  # Orangered
+            "vehicle.car": (255, 158, 0),  # Orange
+            "vehicle.construction": (233, 150, 70),  # Darksalmon
+            "vehicle.emergency.ambulance": (255, 83, 0),
+            "vehicle.emergency.police": (255, 215, 0),  # Gold
+            "vehicle.motorcycle": (255, 61, 99),  # Red
+            "vehicle.trailer": (255, 140, 0),  # Darkorange
+            "vehicle.truck": (255, 99, 71),  # Tomato
+            "flat.driveable_surface": (0, 207, 191),  # nuTonomy green
+            "flat.other": (175, 0, 75),
+            "flat.sidewalk": (75, 0, 75),
+            "flat.terrain": (112, 180, 60),
+            "static.manmade": (222, 184, 135),  # Burlywood
+            "static.other": (255, 228, 196),  # Bisque
+            "static.vegetation": (0, 175, 0),  # Green
+            "vehicle.ego": (255, 240, 245)
+        }
+
+        return classname_to_color
 
     @staticmethod
     def get_label_to_names():

--- a/ml3d/datasets/nuscenes.py
+++ b/ml3d/datasets/nuscenes.py
@@ -7,7 +7,7 @@ import logging
 import yaml
 from scipy.spatial.transform import Rotation as R
 
-from .base_dataset import BaseDataset
+from .base_dataset import BaseDataset, BaseDatasetSplit
 from ..utils import Config, make_dir, DATASET
 from .utils import BEVBox3D
 
@@ -227,12 +227,15 @@ class NuScenes(BaseDataset):
         pass
 
 
-class NuSceneSplit():
+class NuSceneSplit(BaseDatasetSplit):
 
     def __init__(self, dataset, split='train'):
         self.cfg = dataset.cfg
 
         self.infos = dataset.get_split_list(split)
+
+        super().__init__(dataset, split=split)
+
         self.path_list = []
         for info in self.infos:
             self.path_list.append(info['lidar_path'])

--- a/ml3d/datasets/nuscenes.py
+++ b/ml3d/datasets/nuscenes.py
@@ -163,6 +163,7 @@ class NuScenes(BaseDataset):
     @staticmethod
     def read_label_3d(path):
         """Reads lidarseg data from the path provided.
+        
         Returns:
             A data object with lidarseg information.
         """

--- a/ml3d/vis/visualizer.py
+++ b/ml3d/vis/visualizer.py
@@ -393,8 +393,7 @@ class Visualizer:
         def get_colors(self):
             """Returns a list of label keys."""
             return [
-                self._label2color[label]
-                for label in sorted(self._label2color.keys())
+                self._label2color[label] for label in self._label2color.keys()
             ]
 
         def set_on_changed(self, callback):  # takes no args, no return value
@@ -404,7 +403,7 @@ class Visualizer:
             """Updates the labels based on look-up table passsed."""
             self.widget.clear()
             root = self.widget.get_root_item()
-            for key in sorted(labellut.labels.keys()):
+            for key in labellut.labels.keys():
                 lbl = labellut.labels[key]
                 color = lbl.color
                 if len(color) == 3:
@@ -1570,8 +1569,9 @@ class Visualizer:
         """
         # Setup the labels
         lut = LabelLUT()
-        for val in sorted(dataset.label_to_names.values()):
-            lut.add_label(val, val)
+        for key, val in dataset.label_to_names.items():
+            key = str(key)
+            lut.add_label(key, val)
         self.set_lut("labels", lut)
 
         self._consolidate_bounding_boxes = True

--- a/ml3d/vis/visualizer.py
+++ b/ml3d/vis/visualizer.py
@@ -1570,8 +1570,10 @@ class Visualizer:
         # Setup the labels
         lut = LabelLUT()
         for key, val in dataset.label_to_names.items():
-            key = str(key)
-            lut.add_label(key, val)
+            if isinstance(dataset.color_map, dict):
+                lut.add_label(str(key), val, color=dataset.color_map[val])
+            else:
+                lut.add_label(str(key), val)
         self.set_lut("labels", lut)
 
         self._consolidate_bounding_boxes = True

--- a/ml3d/vis/visualizer.py
+++ b/ml3d/vis/visualizer.py
@@ -1115,7 +1115,7 @@ class Visualizer:
             shape = [len(tcloud.point["points"].numpy())]
             scalar = np.zeros(shape, dtype='float32')
         tcloud.point["__visualization_scalar"] = Visualizer._make_tcloud_array(
-            scalar)
+            scalar.astype(np.float32))
 
         flag |= rendering.Scene.UPDATE_UV0_FLAG
 

--- a/scripts/preprocess_nuscenes.py
+++ b/scripts/preprocess_nuscenes.py
@@ -147,12 +147,18 @@ class NuScenesProcess():
             pose_rec = nusc.get('ego_pose', sd_rec['ego_pose_token'])
 
             lidar_path, boxes, _ = nusc.get_sample_data(lidar_token)
-
             lidar_path = os.path.abspath(lidar_path)
             assert os.path.exists(lidar_path)
 
+            lidarseg_path = os.path.join(
+                self.nusc.dataroot,
+                self.nusc.get('lidarseg', lidar_token)['filename'])
+            lidarseg_path = os.path.abspath(lidarseg_path)
+            assert os.path.exists(lidarseg_path)
+
             data = {
                 'lidar_path': lidar_path,
+                'lidarseg_path': lidarseg_path,
                 'token': sample['token'],
                 'lidar2ego_tr': calib_rec['translation'],
                 'lidar2ego_rot': calib_rec['rotation'],


### PR DESCRIPTION
- Modified preprocessing and dataset script to add lidarseg info, new label dict (including both foreground and background classes) and a method to load semantic labels. 
- Modified visualizer to load and show labels correctly
- Added a config to train randlanet on Nuscenes
ref: [lidarseg](https://github.com/nutonomy/nuscenes-devkit/blob/master/docs/instructions_lidarseg.md)

Thanks to [mmdetection3d](https://github.com/open-mmlab/mmdetection3d) project 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/365)
<!-- Reviewable:end -->
