### PR TITLE
Move zero sized elements to device to prevent concatenation of mixed device tensors

### DIFF
--- a/ml3d/torch/models/point_pillars.py
+++ b/ml3d/torch/models/point_pillars.py
@@ -917,10 +917,20 @@ class Anchor3DHead(nn.Module):
                     -1, self.box_code_size)
 
                 if target_bboxes[i].shape[0] == 0:
-                    assigned_bboxes.append(torch.zeros(0, 7))
-                    target_idxs.append(torch.zeros((0,), dtype=torch.long))
-                    pos_idxs.append(torch.zeros((0,), dtype=torch.long))
-                    neg_idxs.append(torch.zeros((0,), dtype=torch.long))
+                    assigned_bboxes.append(
+                        torch.zeros((0, 7), device=pred_bboxes.device))
+                    target_idxs.append(
+                        torch.zeros((0,),
+                                    dtype=torch.long,
+                                    device=pred_bboxes.device))
+                    pos_idxs.append(
+                        torch.zeros((0,),
+                                    dtype=torch.long,
+                                    device=pred_bboxes.device))
+                    neg_idxs.append(
+                        torch.zeros((0,),
+                                    dtype=torch.long,
+                                    device=pred_bboxes.device))
                     continue
 
                 # compute a fast approximation of IoU


### PR DESCRIPTION
Without this change, the NuScenes dataset crashes 20% of the way through the first epoch due to mixed device elements being concatenated together.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/377)
<!-- Reviewable:end -->
