### PR TITLE
Configurable number of epochs between training validation runs

### DIFF
--- a/ml3d/torch/pipelines/object_detection.py
+++ b/ml3d/torch/pipelines/object_detection.py
@@ -316,7 +316,8 @@ class ObjectDetection(BasePipeline):
                 self.scheduler.step()
 
             # --------------------- validation
-            self.run_valid()
+            if (epoch % cfg.get("validation_freq", 1)) == 0:
+                self.run_valid()
 
             self.save_logs(writer, epoch)
 
@@ -327,8 +328,9 @@ class ObjectDetection(BasePipeline):
         for key, val in self.losses.items():
             writer.add_scalar("train/" + key, np.mean(val), epoch)
 
-        for key, val in self.valid_losses.items():
-            writer.add_scalar("valid/" + key, np.mean(val), epoch)
+        if (epoch % cfg.get("validation_freq", 1)) == 0:
+            for key, val in self.valid_losses.items():
+                writer.add_scalar("valid/" + key, np.mean(val), epoch)
 
     def load_ckpt(self, ckpt_path=None, is_resume=True):
         train_ckpt_dir = join(self.cfg.logs_dir, 'checkpoint')


### PR DESCRIPTION
Added support for optional use of `validation_freq` to set how often validation runs during training

Without this change, the validation step runs after every epoch which can significantly slow down training. This change allows the number of epochs between validation steps to be configurable, while maintaining the default behavior of validating after every epoch if unconfigured.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/385)
<!-- Reviewable:end -->
