### PR TITLE
Add bounding boxes to Visualizer DataModel

### DIFF
--- a/ml3d/vis/visualizer.py
+++ b/ml3d/vis/visualizer.py
@@ -220,6 +220,7 @@ class DataModel(Model):
         # We could just create the TPointCloud here, but that would cause the UI
         # to block. If we do it on load then the loading dialog will display.
         self._name2srcdata = {}
+        self.bounding_box_data = []
         for d in userdata:
             name = d["name"]
             while name in self._data:  # ensure each name is unique
@@ -227,10 +228,14 @@ class DataModel(Model):
             self._init_data(name)
             self._name2srcdata[name] = d
 
+            if 'bounding_boxes' in d:
+                self.bounding_box_data.append(
+                    Model.BoundingBoxData(name, d['bounding_boxes']))
+
     def load(self, name, fail_if_no_space=False):
         """Load a pointcloud based on the name provided."""
         if self.is_loaded(name):
-            return
+            return True
 
         self.create_point_cloud(self._name2srcdata[name])
 

--- a/ml3d/vis/visualizer.py
+++ b/ml3d/vis/visualizer.py
@@ -1573,6 +1573,8 @@ class Visualizer:
                         box_data.append(data)
                         current_group = []
             self._objects.bounding_box_data = box_data
+        else:
+            self._consolidate_bounding_boxes = True
 
         self._visualize("Open3D", width, height)
 

--- a/scripts/demo_obj_det.py
+++ b/scripts/demo_obj_det.py
@@ -82,6 +82,7 @@ def main(args):
     data = test_split[5]['data']
 
     # run inference on a single example.
+    data = test_split[5]['data']
     result = pipeline.run_inference(data)[0]
 
     boxes = data['bbox_objs']
@@ -92,6 +93,10 @@ def main(args):
     lut = LabelLUT()
     for val in sorted(dataset.label_to_names.keys()):
         lut.add_label(val, val)
+
+    # Uncommenting this assigns bbox color according to lut
+    # for key, val in sorted(dataset.label_to_names.items()):
+    #     lut.add_label(key, val)
 
     vis.visualize([{
         "name": "KITTI",

--- a/scripts/demo_obj_det.py
+++ b/scripts/demo_obj_det.py
@@ -6,6 +6,7 @@ from open3d.ml.vis import Visualizer, BoundingBox3D, LabelLUT, BEVBox3D
 from open3d.ml.datasets import KITTI
 
 import argparse
+from tqdm import tqdm
 
 
 def parse_args():
@@ -98,6 +99,30 @@ def main(args):
     }],
                   lut,
                   bounding_boxes=boxes)
+
+    # run inference on a multiple examples
+    vis = Visualizer()
+    lut = LabelLUT()
+    for val in sorted(dataset.label_to_names.keys()):
+        lut.add_label(val, val)
+
+    boxes = []
+    data_list = []
+    for idx in tqdm(range(100)):
+        data = test_split[idx]['data']
+
+        result = pipeline.run_inference(data)[0]
+
+        boxes = data['bbox_objs']
+        boxes.extend(result)
+
+        data_list.append({
+            "name": 'KITTI' + '_' + str(idx),
+            'points': data['point'],
+            'bounding_boxes': boxes
+        })
+
+    vis.visualize(data_list, lut, bounding_boxes=None)
 
 
 if __name__ == '__main__':

--- a/scripts/demo_obj_det.py
+++ b/scripts/demo_obj_det.py
@@ -2,7 +2,7 @@ import numpy as np
 import open3d.ml as _ml3d
 import math
 
-from open3d.ml.vis import Visualizer, BoundingBox3D, LabelLUT, BEVBox3D
+from open3d.ml.vis import Visualizer, BoundingBox3D, LabelLUT
 from open3d.ml import datasets
 
 import argparse


### PR DESCRIPTION
- Added `self.bounding_box_data` to Visualizer DataModel. This allows storing/loading bounding boxes alongside the lidar data. This is helpful when inferring object detection on on multiple lidar frames.
- When inferring on single frame, bounding boxes can be passed separately (as before). When inferring on multiple frames, the bounding boxes can be added as a key to the data dictionary.
- Modified script `demo_obj_det.py` to demonstrate single frame as well as multi frame inference scenarios. Also added support to load other object detection datasets.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/392)
<!-- Reviewable:end -->
