### PR TITLE
Intel OpenVINO backend

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -3,8 +3,7 @@ name: Style check
 on:
   workflow_dispatch:
   push:
-    branches:
-      - master
+    branches: [master, dev]
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -3,8 +3,7 @@ name: Ubuntu CI
 on:
   workflow_dispatch:
   push:
-    branches:
-      - master
+    branches: [master, dev]
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ For downloading these datasets visit the respective webpages and have a look at 
 * [Visualize custom data](docs/howtos.md#visualize-custom-data)
 * [Adding a new model](docs/howtos.md#adding-a-new-model)
 * [Adding a new dataset](docs/howtos.md#adding-a-new-dataset)
+* [Inference with Intel OpenVINO](docs/openvino.md)
 
 ## Contribute
 There are many ways to contribute to this project. You can:

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -31,7 +31,7 @@ python -m pip install -U torch==${TORCH_GLNX_VER} -f https://download.pytorch.or
 python -m pip install -U pytest=="$PYTEST_VER" \
     pytest-randomly=="$PYTEST_RANDOMLY_VER"
 python -m pip install -U yapf=="$YAPF_VER"
-python -m pip install -U openvino-dev==2021.4.1
+python -m pip install -U openvino-dev==2021.4.2
 
 echo 3. Configure for bundling the Open3D-ML part
 echo

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -31,6 +31,7 @@ python -m pip install -U torch==${TORCH_GLNX_VER} -f https://download.pytorch.or
 python -m pip install -U pytest=="$PYTEST_VER" \
     pytest-randomly=="$PYTEST_RANDOMLY_VER"
 python -m pip install -U yapf=="$YAPF_VER"
+python -m pip install -U openvino-dev==2021.4.1
 
 echo 3. Configure for bundling the Open3D-ML part
 echo

--- a/docs/openvino.md
+++ b/docs/openvino.md
@@ -1,0 +1,25 @@
+# OpenVINO backend
+
+Open3D-ML allows to use [Intel OpenVINO](https://github.com/openvinotoolkit/openvino) as an optional backend for deep learning models.
+
+## Usage
+
+To enable OpenVINO, wrap a model in `ml3d.models.OpenVINOModel` class. In example,
+
+```python
+net = ml3d.models.PointPillars(**cfg.model, device='cpu')
+net = ml3d.models.OpenVINOModel(net)
+```
+
+Then use `net` as usual.
+
+## Supported hardware
+
+OpenVINO supports Intel CPUs, GPUs and VPUs. By default, model is executed on CPU.
+To switch between devices, use `net.to` option:
+
+```python
+net.to("cpu")     # CPU device (default)
+net.to("gpu")     # GPU device
+net.to("myriad")  # VPU device
+```

--- a/docs/openvino.md
+++ b/docs/openvino.md
@@ -1,6 +1,6 @@
 # OpenVINO backend
 
-Open3D-ML allows to use [Intel OpenVINO](https://github.com/openvinotoolkit/openvino) as an optional backend for deep learning models.
+Open3D-ML allows to use [Intel OpenVINO](https://github.com/openvinotoolkit/openvino) as an optional backend for deep learning models inference.
 
 ## Usage
 
@@ -23,3 +23,9 @@ net.to("cpu")     # CPU device (default)
 net.to("gpu")     # GPU device
 net.to("myriad")  # VPU device
 ```
+
+## Supported models
+
+* `RandLA-Net` (tf, torch)
+* `KPConv` (tf, torch)
+* `PointPillars` (torch)

--- a/ml3d/tf/models/__init__.py
+++ b/ml3d/tf/models/__init__.py
@@ -7,9 +7,14 @@ from .sparseconvnet import SparseConvUnet
 from .point_rcnn import PointRCNN
 from .point_transformer import PointTransformer
 from .pvcnn import PVCNN
-from .openvino_model import OpenVINOModel
 
 __all__ = [
     'RandLANet', 'KPFCNN', 'PointPillars', 'SparseConvUnet', 'PointRCNN',
-    'PointTransformer', 'PVCNN', 'OpenVINOModel'
+    'PointTransformer', 'PVCNN'
 ]
+
+try:
+    from .openvino_model import OpenVINOModel
+    __all__.append("OpenVINOModel")
+except Exception:
+    pass

--- a/ml3d/tf/models/__init__.py
+++ b/ml3d/tf/models/__init__.py
@@ -7,8 +7,9 @@ from .sparseconvnet import SparseConvUnet
 from .point_rcnn import PointRCNN
 from .point_transformer import PointTransformer
 from .pvcnn import PVCNN
+from .openvino_model import OpenVINOModel
 
 __all__ = [
     'RandLANet', 'KPFCNN', 'PointPillars', 'SparseConvUnet', 'PointRCNN',
-    'PointTransformer', 'PVCNN'
+    'PointTransformer', 'PVCNN', 'OpenVINOModel'
 ]

--- a/ml3d/tf/models/openvino_ext/front/tf/min.py
+++ b/ml3d/tf/models/openvino_ext/front/tf/min.py
@@ -1,0 +1,14 @@
+from mo.front.extractor import FrontExtractorOp
+from extensions.ops.ReduceOps import ReduceMin
+from mo.graph.graph import Node
+
+
+class MinFrontExtractor(FrontExtractorOp):
+    op = 'Min'
+    enabled = True
+
+    @classmethod
+    def extract(cls, node: Node):
+        ReduceMin.update_node_stat(node,
+                                   {'keep_dims': node.pb.attr['keep_dims'].b})
+        return cls.enabled

--- a/ml3d/tf/models/openvino_model.py
+++ b/ml3d/tf/models/openvino_model.py
@@ -1,0 +1,67 @@
+import os
+import sys
+import subprocess
+
+import numpy as np
+
+import mo_tf
+from openvino.inference_engine import IECore
+
+
+class OpenVINOModel:
+
+    def __init__(self, base_model):
+        self.ie = IECore()
+        self.exec_net = None
+        self.base_model = base_model
+        self.input_names = None
+        self.input_ids = None
+
+    def _read_tf_model(self, inputs):
+        # Dump a model in SavedModel format
+        self.base_model.save('model')
+
+        # Read input signatures (names, shapes)
+        signatures = self.base_model._get_save_spec()
+
+        self.input_names = []
+        self.input_ids = []
+        input_shapes = []
+        for inp in signatures:
+            inp_idx = int(inp.name[inp.name.find('_') + 1:]) - 1
+            shape = list(inputs[inp_idx].shape)
+
+            if np.prod(shape) == 0:
+                continue
+
+            self.input_names.append(inp.name)
+            self.input_ids.append(inp_idx)
+            input_shapes.append(str(shape))
+
+        # Run Model Optimizer to get IR
+        subprocess.run([
+            sys.executable,
+            mo_tf.__file__,
+            '--saved_model_dir=model',
+            '--input_shape',
+            ','.join(input_shapes),
+            '--input',
+            ','.join(self.input_names),
+            '--extension',
+            os.path.join(os.path.dirname(__file__), 'openvino_ext'),
+        ],
+                       check=True)
+
+        self.exec_net = self.ie.load_network('saved_model.xml', 'CPU')
+
+    def __call__(self, inputs):
+        if self.exec_net is None:
+            self._read_tf_model(inputs)
+
+        tensors = {}
+        for idx, name in zip(self.input_ids, self.input_names):
+            tensors[name] = inputs[idx]
+
+        output = self.exec_net.infer(tensors)
+        output = next(iter(output.values()))
+        return output

--- a/ml3d/tf/models/utils/openvino_ext/front/tf/min.py
+++ b/ml3d/tf/models/utils/openvino_ext/front/tf/min.py
@@ -4,6 +4,11 @@ from mo.graph.graph import Node
 
 
 class MinFrontExtractor(FrontExtractorOp):
+    """Support class which enables missed Min operation in OpenVINO.
+
+    TODO: will be fixed in next OpenVINO release (2022.1)
+    """
+
     op = 'Min'
     enabled = True
 

--- a/ml3d/torch/models/__init__.py
+++ b/ml3d/torch/models/__init__.py
@@ -7,9 +7,14 @@ from .sparseconvnet import SparseConvUnet
 from .point_rcnn import PointRCNN
 from .point_transformer import PointTransformer
 from .pvcnn import PVCNN
-from .openvino_model import OpenVINOModel
 
 __all__ = [
     'RandLANet', 'KPFCNN', 'PointPillars', 'PointRCNN', 'SparseConvUnet',
-    'PointTransformer', 'PVCNN', 'OpenVINOModel'
+    'PointTransformer', 'PVCNN'
 ]
+
+try:
+    from .openvino_model import OpenVINOModel
+    __all__.append("OpenVINOModel")
+except Exception:
+    pass

--- a/ml3d/torch/models/__init__.py
+++ b/ml3d/torch/models/__init__.py
@@ -7,8 +7,9 @@ from .sparseconvnet import SparseConvUnet
 from .point_rcnn import PointRCNN
 from .point_transformer import PointTransformer
 from .pvcnn import PVCNN
+from .openvino_model import OpenVINOModel
 
 __all__ = [
     'RandLANet', 'KPFCNN', 'PointPillars', 'PointRCNN', 'SparseConvUnet',
-    'PointTransformer', 'PVCNN'
+    'PointTransformer', 'PVCNN', 'OpenVINOModel'
 ]

--- a/ml3d/torch/models/kpconv.py
+++ b/ml3d/torch/models/kpconv.py
@@ -1245,7 +1245,7 @@ class BatchNormBlock(nn.Module):
             x = x.transpose(0, 2)
             x = self.batch_norm(x)
             x = x.transpose(0, 2)
-            return x.squeeze()
+            return x.squeeze(2)
         else:
             return x + self.bias
 

--- a/ml3d/torch/models/openvino_model.py
+++ b/ml3d/torch/models/openvino_model.py
@@ -1,4 +1,5 @@
 import io
+import copy
 
 import torch
 
@@ -58,6 +59,7 @@ class OpenVINOModel:
         return inputs
 
     def _read_torch_model(self, inputs):
+        inputs = copy.deepcopy(inputs)
         tensors = self._get_inputs(inputs)
         input_names = self._get_input_names(tensors)
 

--- a/ml3d/torch/models/openvino_model.py
+++ b/ml3d/torch/models/openvino_model.py
@@ -1,0 +1,131 @@
+import io
+
+import torch
+
+from openvino.inference_engine import IECore
+
+from .. import dataloaders
+
+
+def pointpillars_extract_feats(self, x):
+    x = self.backbone(x)
+    x = self.neck(x)
+    return x
+
+
+class OpenVINOModel:
+
+    def __init__(self, base_model):
+        self.ie = IECore()
+        self.exec_net = None
+        self.base_model = base_model
+
+        # A workaround for unsupported torch.square by ONNX
+        torch.square = lambda x: torch.pow(x, 2)
+
+    def _get_input_names(self, inputs):
+        names = []
+        for name, tensor in inputs.items():
+            if isinstance(tensor, list):
+                for i in range(len(tensor)):
+                    names.append(name + str(i))
+            else:
+                names.append(name)
+        return names
+
+    def _get_inputs(self, inputs, export=False):
+        if isinstance(inputs, dataloaders.concat_batcher.KPConvBatch):
+            inputs = {
+                'features': inputs.features,
+                'points': inputs.points,
+                'neighbors': inputs.neighbors,
+                'pools': inputs.pools,
+                'upsamples': inputs.upsamples,
+            }
+        elif isinstance(inputs, dataloaders.concat_batcher.ObjectDetectBatch):
+            voxels, num_points, coors = self.base_model.voxelize(inputs.point)
+            voxel_features = self.base_model.voxel_encoder(
+                voxels, num_points, coors)
+            batch_size = coors[-1, 0].item() + 1
+            x = self.base_model.middle_encoder(voxel_features, coors,
+                                               batch_size)
+
+            inputs = {
+                'x': x,
+            }
+        elif not isinstance(inputs, dict):
+            raise Exception(f"Unknown inputs type: {inputs.__class__}")
+        return inputs
+
+    def _read_torch_model(self, inputs):
+        tensors = self._get_inputs(inputs)
+        input_names = self._get_input_names(tensors)
+
+        # Forward origin inputs instead of export <tensors>
+        origin_forward = self.base_model.forward
+        self.base_model.forward = lambda x: origin_forward(inputs)
+        self.base_model.extract_feats = lambda *args: pointpillars_extract_feats(
+            self.base_model, tensors[input_names[0]])
+
+        buf = io.BytesIO()
+        self.base_model.eval()
+        torch.onnx.export(self.base_model,
+                          tensors,
+                          buf,
+                          input_names=input_names)
+        self.base_model.forward = origin_forward
+
+        net = self.ie.read_network(buf.getvalue(), b'', init_from_buffer=True)
+        self.exec_net = self.ie.load_network(net, 'CPU')
+
+    def forward(self, inputs):
+        if self.exec_net is None:
+            self._read_torch_model(inputs)
+
+        inputs = self._get_inputs(inputs)
+
+        tensors = {}
+        for name, tensor in inputs.items():
+            if name == 'labels':
+                continue
+            if isinstance(tensor, list):
+                for i in range(len(tensor)):
+                    if tensor[i].nelement() > 0:
+                        tensors[name + str(i)] = tensor[i].detach().numpy()
+            else:
+                if tensor.nelement() > 0:
+                    tensors[name] = tensor.detach().numpy()
+
+        output = self.exec_net.infer(tensors)
+
+        if len(output) == 1:
+            output = next(iter(output.values()))
+            return torch.tensor(output)
+        else:
+            return tuple([torch.tensor(out) for out in output.values()])
+
+    def __call__(self, inputs):
+        return self.forward(inputs)
+
+    def load_state_dict(self, *args):
+        self.base_model.load_state_dict(*args)
+
+    def eval(self):
+        pass
+
+    @property
+    def cfg(self):
+        return self.base_model.cfg
+
+    @property
+    def classes(self):
+        return self.base_model.classes
+
+    def inference_end(self, *args):
+        return self.base_model.inference_end(*args)
+
+    def preprocess(self, *args):
+        return self.base_model.preprocess(*args)
+
+    def transform(self, *args):
+        return self.base_model.transform(*args)

--- a/requirements-tensorflow.txt
+++ b/requirements-tensorflow.txt
@@ -1,2 +1,2 @@
 tensorflow~=2.5.2
-openvino-dev==2021.4.1
+openvino-dev==2021.4.2

--- a/requirements-tensorflow.txt
+++ b/requirements-tensorflow.txt
@@ -1,1 +1,2 @@
 tensorflow~=2.5.2
+openvino-dev==2021.4.1

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -4,4 +4,4 @@ torchvision==0.9.2+cpu ; sys_platform != 'darwin'
 torch==1.8.1 ; sys_platform == 'darwin'
 torchvision==0.9.1 ; sys_platform == 'darwin'
 tensorboard
-openvino==2021.4.1
+openvino==2021.4.2

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -4,3 +4,4 @@ torchvision==0.9.2+cpu ; sys_platform != 'darwin'
 torch==1.8.1 ; sys_platform == 'darwin'
 torchvision==0.9.1 ; sys_platform == 'darwin'
 tensorboard
+openvino==2021.4.1

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -42,4 +42,18 @@ def test_integration_tf():
     print(model)
 
 
+def test_integration_openvino():
+    try:
+        from openvino.inference_engine import IECore
+        openvino_available = True
+    except:
+        openvino_available = False
+
+    if not openvino_available:
+        return
+
+    from open3d.ml.torch.models import OpenVINOModel
+    from open3d.ml.tf.models import OpenVINOModel
+
+
 test_integration_torch()


### PR DESCRIPTION
To enable OpenVINO, wrap a model by `ml3d.models.OpenVINOModel`

```python
net = ml3d.models.PointPillars(**cfg.model, device='cpu')
ov_net = ml3d.models.OpenVINOModel(net)
```

## Enabled models

| Model / Framework    | ported to OpenVINO |
|--------------------|---------------|
| RandLA-Net (tf)    |  + |
| RandLA-Net (torch) | + (Gather takes too much memory and execution time)
| KPConv     (tf)    | + |
| KPConv     (torch) | + |
| SparseConvUnet (torch)|
| SparseConvUnet (tf)| 
| PointPillars (tf)    | |
| PointPillars (torch) | + |
| PointRCNN (tf)       | |

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/406)
<!-- Reviewable:end -->
