### PR TITLE
update links for torch 1.8.1

### DIFF
--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,7 +1,7 @@
-https://github.com/isl-org/open3d_downloads/releases/download/torch1.8.1/torch-1.8.1-cp36-cp36m-linux_x86_64.whl ; python_version == '3.6'
-https://github.com/isl-org/open3d_downloads/releases/download/torch1.8.1/torch-1.8.1-cp37-cp37m-linux_x86_64.whl ; python_version == '3.7'
-https://github.com/isl-org/open3d_downloads/releases/download/torch1.8.1/torch-1.8.1-cp38-cp38-linux_x86_64.whl ; python_version == '3.8'
-https://github.com/isl-org/open3d_downloads/releases/download/torch1.8.1/torch-1.8.1-cp39-cp39-linux_x86_64.whl ; python_version == '3.9'
+https://s3.eu-central-1.wasabisys.com/open3d-share/torch-1.8.1-cp36-cp36m-linux_x86_64.whl ; python_version == '3.6'
+https://s3.eu-central-1.wasabisys.com/open3d-share/torch-1.8.1-cp37-cp37m-linux_x86_64.whl ; python_version == '3.7'
+https://s3.eu-central-1.wasabisys.com/open3d-share/torch-1.8.1-cp38-cp38-linux_x86_64.whl ; python_version == '3.8'
+https://s3.eu-central-1.wasabisys.com/open3d-share/torch-1.8.1-cp39-cp39-linux_x86_64.whl ; python_version == '3.9'
 -f https://download.pytorch.org/whl/lts/1.8/torch_lts.html
 torchvision==0.9.1+cu111
 tensorboard


### PR DESCRIPTION
We were getting some timeout errors for Open3D CI. Moving to a more stable data host.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/410)
<!-- Reviewable:end -->
