### PR TITLE
update links for torch 1.7.1

### DIFF
--- a/requirements-torch-cuda.txt
+++ b/requirements-torch-cuda.txt
@@ -1,6 +1,6 @@
-https://github.com/isl-org/open3d_downloads/releases/download/torch1.7.1/torch-1.7.1-cp36-cp36m-linux_x86_64.whl ; python_version == '3.6'
-https://github.com/isl-org/open3d_downloads/releases/download/torch1.7.1/torch-1.7.1-cp37-cp37m-linux_x86_64.whl ; python_version == '3.7'
-https://github.com/isl-org/open3d_downloads/releases/download/torch1.7.1/torch-1.7.1-cp38-cp38-linux_x86_64.whl ; python_version == '3.8'
+https://s3.eu-central-1.wasabisys.com/open3d-share/torch-1.7.1-cp36-cp36m-linux_x86_64.whl ; python_version == '3.6'
+https://s3.eu-central-1.wasabisys.com/open3d-share/torch-1.7.1-cp37-cp37m-linux_x86_64.whl ; python_version == '3.7'
+https://s3.eu-central-1.wasabisys.com/open3d-share/torch-1.7.1-cp38-cp38-linux_x86_64.whl ; python_version == '3.8'
 -f https://download.pytorch.org/whl/torch_stable.html
 torchvision==0.8.2+cu110
 tensorboard


### PR DESCRIPTION
We were getting some timeout errors for Open3D CI. Moving to a more stable data host.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/411)
<!-- Reviewable:end -->
