### PR TITLE
fix `get_confusion_matrix` for predictions with fewer classes than the gt

### DIFF
--- a/examples/vis_pred.py
+++ b/examples/vis_pred.py
@@ -34,13 +34,11 @@ def pred_custom_data(pc_names, pcs, pipeline_r, pipeline_k):
 
         results_r = pipeline_r.run_inference(data)
         pred_label_r = (results_r['predict_labels'] + 1).astype(np.int32)
-        # WARNING, THIS IS A HACK
         # Fill "unlabeled" value because predictions have no 0 values.
         pred_label_r[0] = 0
 
         results_k = pipeline_k.run_inference(data)
         pred_label_k = (results_k['predict_labels'] + 1).astype(np.int32)
-        # WARNING, THIS IS A HACK
         # Fill "unlabeled" value because predictions have no 0 values.
         pred_label_k[0] = 0
 

--- a/ml3d/tf/modules/metrics/semseg_metric.py
+++ b/ml3d/tf/modules/metrics/semseg_metric.py
@@ -95,7 +95,7 @@ class SemSegMetric(object):
         """Computes the confusion matrix of one batch
 
         Args:
-            scores (tf.FloatTensor, shape (B?, C, N):
+            scores (tf.FloatTensor, shape (B?, N, C):
                 raw scores for each class.
             labels (tf.LongTensor, shape (B?, N)):
                 ground truth labels.
@@ -113,6 +113,8 @@ class SemSegMetric(object):
 
         if len(y) < C * C:
             y = np.concatenate([y, np.zeros((C * C - len(y)), dtype=np.long)])
+        else:
+            y = y[:C*C]
 
         y = y.reshape(C, C)
 

--- a/ml3d/tf/modules/metrics/semseg_metric.py
+++ b/ml3d/tf/modules/metrics/semseg_metric.py
@@ -114,7 +114,7 @@ class SemSegMetric(object):
         if len(y) < C * C:
             y = np.concatenate([y, np.zeros((C * C - len(y)), dtype=np.long)])
         else:
-            y = y[:C*C]
+            y = y[:C * C]
 
         y = y.reshape(C, C)
 

--- a/ml3d/tf/modules/metrics/semseg_metric.py
+++ b/ml3d/tf/modules/metrics/semseg_metric.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 
 
 class SemSegMetric(object):
@@ -114,7 +115,11 @@ class SemSegMetric(object):
         if len(y) < C * C:
             y = np.concatenate([y, np.zeros((C * C - len(y)), dtype=np.long)])
         else:
-            y = y[:C * C]
+            if len(y) > C * C:
+                warnings.warn(
+                    "Prediction has fewer classes than ground truth. This may affect accuracy."
+                )
+            y = y[-(C * C):]  # last c*c elements.
 
         y = y.reshape(C, C)
 

--- a/ml3d/torch/modules/metrics/semseg_metric.py
+++ b/ml3d/torch/modules/metrics/semseg_metric.py
@@ -95,7 +95,7 @@ class SemSegMetric(object):
         """Computes the confusion matrix of one batch
 
         Args:
-            scores (torch.FloatTensor, shape (B?, C, N):
+            scores (torch.FloatTensor, shape (B?, N, C):
                 raw scores for each class.
             labels (torch.LongTensor, shape (B?, N)):
                 ground truth labels.
@@ -113,6 +113,8 @@ class SemSegMetric(object):
 
         if len(y) < C * C:
             y = np.concatenate([y, np.zeros((C * C - len(y)), dtype=np.long)])
+        else:
+            y = y[:C*C]
 
         y = y.reshape(C, C)
 

--- a/ml3d/torch/modules/metrics/semseg_metric.py
+++ b/ml3d/torch/modules/metrics/semseg_metric.py
@@ -114,7 +114,7 @@ class SemSegMetric(object):
         if len(y) < C * C:
             y = np.concatenate([y, np.zeros((C * C - len(y)), dtype=np.long)])
         else:
-            y = y[:C*C]
+            y = y[:C * C]
 
         y = y.reshape(C, C)
 

--- a/ml3d/torch/modules/metrics/semseg_metric.py
+++ b/ml3d/torch/modules/metrics/semseg_metric.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 
 
 class SemSegMetric(object):
@@ -114,7 +115,11 @@ class SemSegMetric(object):
         if len(y) < C * C:
             y = np.concatenate([y, np.zeros((C * C - len(y)), dtype=np.long)])
         else:
-            y = y[:C * C]
+            if len(y) > C * C:
+                warnings.warn(
+                    "Prediction has fewer classes than ground truth. This may affect accuracy."
+                )
+            y = y[-(C * C):]  # last c*c elements.
 
         y = y.reshape(C, C)
 


### PR DESCRIPTION
This PR fixes an incompatible shape problem in `get_confusion_matrix` if the prediction has fewer classes than the ground truth.

Problem occurs when running `examples/vis_pred.py`, discovered by @theNded .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/421)
<!-- Reviewable:end -->
