### PR TITLE
update pl3d, s3dis, scannet and semantic3d datasets to BaseDataSplit

### DIFF
--- a/ml3d/datasets/parislille3d.py
+++ b/ml3d/datasets/parislille3d.py
@@ -181,7 +181,8 @@ class ParisLille3DSplit(BaseDatasetSplit):
 
     def __init__(self, dataset, split='training'):
         super().__init__(dataset, split=split)
-        log.info("Found {} pointclouds for {}".format(len(self.path_list), split))
+        log.info("Found {} pointclouds for {}".format(len(self.path_list),
+                                                      split))
 
     def __len__(self):
         return len(self.path_list)

--- a/ml3d/datasets/parislille3d.py
+++ b/ml3d/datasets/parislille3d.py
@@ -181,6 +181,7 @@ class ParisLille3DSplit(BaseDatasetSplit):
 
     def __init__(self, dataset, split='training'):
         super().__init__(dataset, split=split)
+        log.info("Found {} pointclouds for {}".format(len(self.path_list), split))
 
     def __len__(self):
         return len(self.path_list)

--- a/ml3d/datasets/s3dis.py
+++ b/ml3d/datasets/s3dis.py
@@ -265,7 +265,8 @@ class S3DISSplit(BaseDatasetSplit):
 
     def __init__(self, dataset, split='training'):
         super().__init__(dataset, split=split)
-        log.info("Found {} pointclouds for {}".format(len(self.path_list), split))
+        log.info("Found {} pointclouds for {}".format(len(self.path_list),
+                                                      split))
 
     def __len__(self):
         return len(self.path_list)

--- a/ml3d/datasets/s3dis.py
+++ b/ml3d/datasets/s3dis.py
@@ -265,14 +265,7 @@ class S3DISSplit(BaseDatasetSplit):
 
     def __init__(self, dataset, split='training'):
         super().__init__(dataset, split=split)
-
-        self.cfg = dataset.cfg
-        path_list = dataset.get_split_list(split)
-        log.info("Found {} pointclouds for {}".format(len(path_list), split))
-
-        self.path_list = path_list
-        self.split = split
-        self.dataset = dataset
+        log.info("Found {} pointclouds for {}".format(len(self.path_list), split))
 
     def __len__(self):
         return len(self.path_list)

--- a/ml3d/datasets/scannet.py
+++ b/ml3d/datasets/scannet.py
@@ -171,15 +171,9 @@ class ScannetSplit(BaseDatasetSplit):
 
     def __init__(self, dataset, split='train'):
         super().__init__(dataset, split)
-        self.cfg = dataset.cfg
-
-        self.path_list = dataset.get_split_list(split)
-
         log.info("Found {} pointclouds for {}".format(len(self.path_list),
                                                       split))
 
-        self.split = split
-        self.dataset = dataset
 
     def __len__(self):
         return len(self.path_list)

--- a/ml3d/datasets/scannet.py
+++ b/ml3d/datasets/scannet.py
@@ -174,7 +174,6 @@ class ScannetSplit(BaseDatasetSplit):
         log.info("Found {} pointclouds for {}".format(len(self.path_list),
                                                       split))
 
-
     def __len__(self):
         return len(self.path_list)
 

--- a/ml3d/datasets/semantic3d.py
+++ b/ml3d/datasets/semantic3d.py
@@ -216,7 +216,8 @@ class Semantic3DSplit(BaseDatasetSplit):
 
     def __init__(self, dataset, split='training'):
         super().__init__(dataset, split=split)
-        log.info("Found {} pointclouds for {}".format(len(self.path_list), split))
+        log.info("Found {} pointclouds for {}".format(len(self.path_list),
+                                                      split))
 
     def __len__(self):
         return len(self.path_list)

--- a/ml3d/datasets/semantic3d.py
+++ b/ml3d/datasets/semantic3d.py
@@ -216,14 +216,7 @@ class Semantic3DSplit(BaseDatasetSplit):
 
     def __init__(self, dataset, split='training'):
         super().__init__(dataset, split=split)
-
-        self.cfg = dataset.cfg
-        path_list = dataset.get_split_list(split)
-        log.info("Found {} pointclouds for {}".format(len(path_list), split))
-
-        self.path_list = path_list
-        self.split = split
-        self.dataset = dataset
+        log.info("Found {} pointclouds for {}".format(len(self.path_list), split))
 
     def __len__(self):
         return len(self.path_list)


### PR DESCRIPTION
Remove unnecessary code and make use of base class member  [BaseDatasetSplit](https://github.com/isl-org/Open3D-ML/blob/c730f4640e2c134087861184a68356dd19a2e4d2/ml3d/datasets/base_dataset.py#L107) within:
- ParisLille3DSplit
- S3DISSplit
- ScannetSplit
- Semantic3DSplit

I have not been sure what to do with the other Datasets, since they do not (yet?) inherit from the base class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/451)
<!-- Reviewable:end -->
