### PR TITLE
Fix missing axis_align_matrix in Scannet preprocesing

### DIFF
--- a/scripts/preprocess_scannet.py
+++ b/scripts/preprocess_scannet.py
@@ -128,6 +128,7 @@ class ScannetProcess():
 
         # Load axis alignment matrix
         lines = open(meta_file).readlines()
+        axis_align_matrix = np.eye(4)
         for line in lines:
             if 'axisAlignment' in line:
                 axis_align_matrix = [


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/456)
<!-- Reviewable:end -->
