### PR TITLE
Fix and refactor config parsing and merging

### DIFF
--- a/ml3d/utils/config.py
+++ b/ml3d/utils/config.py
@@ -160,34 +160,7 @@ class Config(object):
         }
         cfg = Config(cfg_dict)
 
-        if args.device is not None:
-            cfg.pipeline.device = args.device
-        if args.split is not None:
-            cfg.pipeline.split = args.split
-        if args.main_log_dir is not None:
-            cfg.pipeline.main_log_dir = args.main_log_dir
-        if args.dataset_path is not None:
-            cfg.dataset.dataset_path = args.dataset_path
-
-        extra_cfg_dict = {'model': {}, 'dataset': {}, 'pipeline': {}}
-
-        for full_key, v in extra_dict.items():
-            d = extra_cfg_dict
-            key_list = full_key.split('.')
-            for subkey in key_list[:-1]:
-                d.setdefault(subkey, ConfigDict())
-                d = d[subkey]
-            subkey = key_list[-1]
-            d[subkey] = v
-
-        cfg_dict_dataset = Config._merge_a_into_b(cfg.dataset,
-                                                  extra_cfg_dict['dataset'])
-        cfg_dict_pipeline = Config._merge_a_into_b(cfg.pipeline,
-                                                   extra_cfg_dict['pipeline'])
-        cfg_dict_model = Config._merge_a_into_b(cfg.model,
-                                                extra_cfg_dict['model'])
-
-        return cfg_dict_dataset, cfg_dict_pipeline, cfg_dict_model
+        return Config.merge_cfg_file(cfg, args, extra_dict)
 
     @staticmethod
     def _merge_a_into_b(a, b):


### PR DESCRIPTION
* Resolve issues in `merge_module_cfg_file` regarding command line handling when a config file is not in use:
    * Parameters passed on the command line were not parsed into their correct types and remained as strings, which caused downstream failures
    * Module configuration overrides command line configuration.
    * Resolved by swapping the order of the arguments to `_merge_a_into_b`
* `merge_module_cfg_file` now delegates to `merge_cfg_file` as the implementations are now aligned

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/460)
<!-- Reviewable:end -->
