### PR TITLE
OpenVINO SparseConvUNet

### DIFF
--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -31,8 +31,7 @@ python -m pip install -U torch==${TORCH_GLNX_VER} -f https://download.pytorch.or
 python -m pip install -U pytest=="$PYTEST_VER" \
     pytest-randomly=="$PYTEST_RANDOMLY_VER"
 python -m pip install -U yapf=="$YAPF_VER"
-python -m pip install -U openvino-dev==2021.4.2
-python -m pip install -i https://test.pypi.org/simple/ openvino-extensions~=2021.4.2
+python -m pip install -U openvino-dev==2021.4.2 openvino-extensions~=2021.4.2
 
 echo 3. Configure for bundling the Open3D-ML part
 echo

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -31,7 +31,8 @@ python -m pip install -U torch==${TORCH_GLNX_VER} -f https://download.pytorch.or
 python -m pip install -U pytest=="$PYTEST_VER" \
     pytest-randomly=="$PYTEST_RANDOMLY_VER"
 python -m pip install -U yapf=="$YAPF_VER"
-python -m pip install -U openvino-dev==2021.4.2 openvino-extensions~=2021.4.2
+python -m pip install -U openvino-dev==2021.4.2
+python -m pip install -i https://test.pypi.org/simple/ openvino-extensions~=2021.4.2
 
 echo 3. Configure for bundling the Open3D-ML part
 echo

--- a/ci/run_ci.sh
+++ b/ci/run_ci.sh
@@ -31,7 +31,7 @@ python -m pip install -U torch==${TORCH_GLNX_VER} -f https://download.pytorch.or
 python -m pip install -U pytest=="$PYTEST_VER" \
     pytest-randomly=="$PYTEST_RANDOMLY_VER"
 python -m pip install -U yapf=="$YAPF_VER"
-python -m pip install -U openvino-dev==2021.4.2
+python -m pip install -U openvino-dev==2021.4.2 openvino-extensions~=2021.4.2
 
 echo 3. Configure for bundling the Open3D-ML part
 echo

--- a/ml3d/torch/models/openvino_model.py
+++ b/ml3d/torch/models/openvino_model.py
@@ -22,7 +22,9 @@ class OpenVINOModel:
 
     def __init__(self, base_model):
         self.ie = IECore()
-        self.ie.add_extension("/home/dkurt/openvino_pytorch_unpool/user_ie_extensions/build/libuser_cpu_extension.so", "CPU")
+        self.ie.add_extension(
+            "/home/dkurt/openvino_pytorch_unpool/user_ie_extensions/build/libuser_cpu_extension.so",
+            "CPU")
         self.exec_net = None
         self.base_model = base_model
         self.device = "CPU"
@@ -112,7 +114,8 @@ class OpenVINOModel:
         torch.onnx.export(self.base_model,
                           tensors,
                           buf,
-                          operator_export_type=torch.onnx.OperatorExportTypes.ONNX_FALLTHROUGH,
+                          operator_export_type=torch.onnx.OperatorExportTypes.
+                          ONNX_FALLTHROUGH,
                           input_names=input_names)
 
         self.base_model.forward = origin_forward

--- a/ml3d/torch/models/openvino_model.py
+++ b/ml3d/torch/models/openvino_model.py
@@ -3,6 +3,7 @@ import copy
 
 import torch
 
+from openvino_extensions import get_extensions_path
 from openvino.inference_engine import IECore
 
 from .. import dataloaders
@@ -22,9 +23,7 @@ class OpenVINOModel:
 
     def __init__(self, base_model):
         self.ie = IECore()
-        self.ie.add_extension(
-            "/home/dkurt/openvino_pytorch_unpool/user_ie_extensions/build/libuser_cpu_extension.so",
-            "CPU")
+        self.ie.add_extension(get_extensions_path(), "CPU")
         self.exec_net = None
         self.base_model = base_model
         self.device = "CPU"

--- a/ml3d/torch/models/openvino_model.py
+++ b/ml3d/torch/models/openvino_model.py
@@ -115,6 +115,7 @@ class OpenVINOModel:
                           buf,
                           operator_export_type=torch.onnx.OperatorExportTypes.
                           ONNX_FALLTHROUGH,
+                          opset_version=11,
                           input_names=input_names)
 
         self.base_model.forward = origin_forward

--- a/ml3d/torch/models/sparseconvnet.py
+++ b/ml3d/torch/models/sparseconvnet.py
@@ -149,9 +149,9 @@ class SparseConvUnet(BaseModel):
         # Here
         feat_list = self.sub_sparse_conv(feat_list, pos_list, voxel_size=1.0)
         feat_list = self.unet(pos_list, feat_list)
-        # feat_list = self.batch_norm(feat_list)
-        # feat_list = self.relu(feat_list)
-        # feat_list = self.linear(feat_list)
+        feat_list = self.batch_norm(feat_list)
+        feat_list = self.relu(feat_list)
+        feat_list = self.linear(feat_list)
         output = self.output_layer(feat_list, index_map_list)
 
         return output

--- a/ml3d/torch/models/sparseconvnet.py
+++ b/ml3d/torch/models/sparseconvnet.py
@@ -19,7 +19,7 @@ class SparseConvFunc(torch.autograd.Function):
         kernel = g.op("Constant", value_t=kernel)
         offset = g.op("Constant", value_t=offset)
         name = f"org.open3d::SparseConv{'Transpose' if transpose else ''}"
-        return g.op(name, feat, in_pos, kernel, offset)
+        return g.op(name, feat, in_pos, out_pos, kernel, offset)
 
     @staticmethod
     def forward(self, cls, feat, in_pos, out_pos, voxel_size, transpose):

--- a/ml3d/torch/models/sparseconvnet.py
+++ b/ml3d/torch/models/sparseconvnet.py
@@ -11,6 +11,7 @@ from open3d.ml.torch.ops import voxelize, reduce_subarrays_sum
 
 
 class SparseConvFunc(torch.autograd.Function):
+
     @staticmethod
     def symbolic(g, cls, feat, in_pos, out_pos, voxel_size, transpose):
         kernel = cls.state_dict()["kernel"]
@@ -29,24 +30,28 @@ class SparseConvONNX(SparseConv):
     """
     This is a support class which helps export network with SparseConv in ONNX format.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.origin_forward = super().forward
 
     def forward(self, feat, in_pos, out_pos, voxel_size):
-        return SparseConvFunc.apply(self, feat, in_pos, out_pos, voxel_size, False)
+        return SparseConvFunc.apply(self, feat, in_pos, out_pos, voxel_size,
+                                    False)
 
 
 class SparseConvTransposeONNX(SparseConvTranspose):
     """
     This is a support class which helps export network with SparseConvTranspose in ONNX format.
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.origin_forward = super().forward
 
     def forward(self, feat, in_pos, out_pos, voxel_size):
-        return SparseConvFunc.apply(self, feat, in_pos, out_pos, voxel_size, True)
+        return SparseConvFunc.apply(self, feat, in_pos, out_pos, voxel_size,
+                                    True)
 
 
 class SparseConvUnet(BaseModel):
@@ -445,6 +450,7 @@ def calculate_grid(in_positions):
 # There are issues with calculate_grid export with ONNX and inference using OpenVINO,
 # so we implement it in C++
 class CalculateGridONNX(torch.autograd.Function):
+
     @staticmethod
     def symbolic(g, in_positions):
         return g.op("org.open3d::calculate_grid", in_positions)

--- a/ml3d/torch/models/sparseconvnet.py
+++ b/ml3d/torch/models/sparseconvnet.py
@@ -27,7 +27,8 @@ class SparseConvFunc(torch.autograd.Function):
 
 
 class SparseConvONNX(SparseConv):
-    """
+    """ONNX compatible SparseConv
+
     This is a support class which helps export network with SparseConv in ONNX format.
     """
 
@@ -41,7 +42,8 @@ class SparseConvONNX(SparseConv):
 
 
 class SparseConvTransposeONNX(SparseConvTranspose):
-    """
+    """ONNX compatible SparseConvTranspose
+
     This is a support class which helps export network with SparseConvTranspose in ONNX format.
     """
 
@@ -450,6 +452,10 @@ def calculate_grid(in_positions):
 # There are issues with calculate_grid export with ONNX and inference using OpenVINO,
 # so we implement it in C++
 class CalculateGridONNX(torch.autograd.Function):
+    """ONNX compatible wrapper for calculate_grid method
+
+    This is a support class which helps export network in ONNX format.
+    """
 
     @staticmethod
     def symbolic(g, in_positions):

--- a/ml3d/torch/models/sparseconvnet.py
+++ b/ml3d/torch/models/sparseconvnet.py
@@ -277,16 +277,10 @@ class BatchNormBlock(nn.Module):
         self.bn = nn.BatchNorm1d(m, eps=eps, momentum=momentum)
 
     def forward(self, feat_list):
-        # lengths = [feat.shape[0] for feat in feat_list]
-        # out = self.bn(torch.cat(feat_list, 0))
-        # out_list = []
-        # start = 0
-        # for l in lengths:
-        #     out_list.append(out[start:start + l])
-        #     start += l
-
-        # return out_list
-        return [self.bn(feat) for feat in feat_list]
+        lengths = [feat.shape[0] for feat in feat_list]
+        out = self.bn(torch.cat(feat_list, 0))
+        out_list = torch.split(out, lengths)
+        return out_list
 
     def __name__(self):
         return "BatchNormBlock"
@@ -299,16 +293,10 @@ class ReLUBlock(nn.Module):
         self.relu = nn.ReLU()
 
     def forward(self, feat_list):
-        # lengths = [feat.shape[0] for feat in feat_list]
-        # out = self.relu(torch.cat(feat_list, 0))
-        # out_list = []
-        # start = 0
-        # for l in lengths:
-        #     out_list.append(out[start:start + l])
-        #     start += l
-
-        # return out_list
-        return [self.relu(feat) for feat in feat_list]
+        lengths = [feat.shape[0] for feat in feat_list]
+        out = self.relu(torch.cat(feat_list, 0))
+        out_list = torch.split(out, lengths)
+        return out_list
 
     def __name__(self):
         return "ReLUBlock"

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -5,5 +5,4 @@ torch==1.8.1 ; sys_platform == 'darwin'
 torchvision==0.9.1 ; sys_platform == 'darwin'
 tensorboard
 openvino==2021.4.2
---index https://test.pypi.org/simple
 openvino-extensions~=2021.4.2

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -5,3 +5,4 @@ torch==1.8.1 ; sys_platform == 'darwin'
 torchvision==0.9.1 ; sys_platform == 'darwin'
 tensorboard
 openvino==2021.4.2
+openvino-extensions~=2021.4.2

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -5,4 +5,5 @@ torch==1.8.1 ; sys_platform == 'darwin'
 torchvision==0.9.1 ; sys_platform == 'darwin'
 tensorboard
 openvino==2021.4.2
+--index https://test.pypi.org/simple
 openvino-extensions~=2021.4.2

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -252,10 +252,15 @@ def test_sparseconv_torch():
     net = ml3d.models.SparseConvUnet(**cfg.model, device='cpu')
 
     batcher = ml3d.dataloaders.ConcatBatcher('cpu', model='SparseConvUnet')
+
+    inp_pos = np.random.randint(0, 10, [1000, 3])
+    inp_pos = np.unique(inp_pos, axis=0).astype(np.float32)
+    inp_pos += np.random.random(inp_pos.shape).astype(np.float32)  # [0, 1)
     data = {
-        'feat': np.array(np.random.random((1000, 3)), dtype=np.float32),
-        'point': np.array(np.random.random((1000, 3)), dtype=np.float32),
+        'feat': np.array(np.random.random(inp_pos.shape), dtype=np.float32),
+        'point': inp_pos,
     }
+
     data = net.preprocess(data, {'split': 'test'})
     data = net.transform(data, {'split': 'test'})
     data = batcher.collate_fn([{'data': data, 'attr': {'split': 'test'}}])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -263,12 +263,10 @@ def test_sparseconv_torch():
     net.eval()
     with torch.no_grad():
         results = net(data['data'])
-        print(results)
 
     if openvino_available:
         ov_net = ml3d.models.OpenVINOModel(net)
         ov_results = ov_net(data['data'])
-        print(ov_results)
 
-    assert results.shape == ov_results.shape
-    assert torch.max(torch.abs(results - ov_results)) < 1e-3
+        assert results.shape == ov_results.shape
+        assert torch.max(torch.abs(results - ov_results)) < 1e-3


### PR DESCRIPTION
At this moment, SparseConv is not implemented in OpenVINO but I've published an extension which provides reference implementation of the following layers:
* SparseConv
* SparseContTranspose
* `calculate_grid`. The method is not ONNX compatible so it's exported as a single node

resolves https://github.com/isl-org/Open3D-ML/issues/449

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/467)
<!-- Reviewable:end -->
