### PR TITLE
Getting rid of `torch._six` (for future PyTorch versions)

### DIFF
--- a/ml3d/torch/dataloaders/default_batcher.py
+++ b/ml3d/torch/dataloaders/default_batcher.py
@@ -3,7 +3,6 @@ import collections
 
 import torch
 
-
 container_abcs = collections.abc
 string_classes = (str, bytes)
 np_str_obj_array_pattern = re.compile(r'[SaUO]')

--- a/ml3d/torch/dataloaders/default_batcher.py
+++ b/ml3d/torch/dataloaders/default_batcher.py
@@ -1,5 +1,8 @@
-import torch
 import re
+import collections
+
+import torch
+
 
 container_abcs = collections.abc
 string_classes = (str, bytes)

--- a/ml3d/torch/dataloaders/default_batcher.py
+++ b/ml3d/torch/dataloaders/default_batcher.py
@@ -1,7 +1,8 @@
 import torch
 import re
-from torch._six import container_abcs, string_classes, int_classes
 
+container_abcs = collections.abc
+string_classes = (str, bytes)
 np_str_obj_array_pattern = re.compile(r'[SaUO]')
 
 
@@ -59,7 +60,7 @@ def default_collate(batch):
             return torch.as_tensor(batch)
     elif isinstance(elem, float):
         return torch.tensor(batch, dtype=torch.float64)
-    elif isinstance(elem, int_classes):
+    elif isinstance(elem, int):
         return torch.tensor(batch)
     elif isinstance(elem, string_classes):
         return batch


### PR DESCRIPTION
Hi, I understand this library currently supports PyTorch version: `1.8.*` but as we move along, and Open3D decided to support newer versions of PyTorch, it would help if we can get rid of `torch._six` completely.

## Why is this needed?

So I faced this problem where I was testing a code which uses this library. The errors that I got were first related to `torch._six`.

```bash
ImportError: cannot import name 'container_abcs' from 'torch._six'
```

Had to dig around to find, that `torch._six` had removed this from their library. Makes sense, since the community has started moving to Python 3.x versions.

Once these fixes were done, it gave me a clearer error that I was just using a newer version of PyTorch:

```bash
Exception: Version mismatch: Open3D needs PyTorch version 1.8.*, but version 1.10.2+cu113 is installed!
```

I think, it would be good if we get rid of `torch._six` completely, and use better alternatives, so that a user using inappropriate version of PyTorch gets a clear error instead of `torch._six` import errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/486)
<!-- Reviewable:end -->

cc: @sanskar107 