### PR TITLE
Fix moving zip files

### DIFF
--- a/scripts/download_datasets/download_semantic3d.sh
+++ b/scripts/download_datasets/download_semantic3d.sh
@@ -58,5 +58,5 @@ mv $BASE_DIR/station1_xyz_intensity_rgb.txt $BASE_DIR/neugasse_station1_xyz_inte
 
 # cleanup
 mkdir -p $BASE_DIR/zip_files
-mv *.7z $BASE_DIR/zip_files
+mv $BASE_DIR/*.7z $BASE_DIR/zip_files
 


### PR DESCRIPTION
Fixed missing $BASE_DIR in the move command for zip files.