### PR TITLE
Handle nested dictionaries when merging configs

### DIFF
--- a/ml3d/utils/config.py
+++ b/ml3d/utils/config.py
@@ -170,15 +170,15 @@ class Config(object):
         # from mmcv mmcv/utils/config.py
         b = b.copy()
         for k, v in a.items():
-            if isinstance(v, dict) and k in b:
-                if not isinstance(b[k], dict):
+            if isinstance(v, dict):
+                if k in b and not isinstance(b[k], dict):
                     raise TypeError(
                         "{}={} in child config cannot inherit from base ".
                         format(k, v) +
                         "because {} is a dict in the child config but is of ".
                         format(k) +
                         "type {} in base config.  ".format(type(b[k])))
-                b[k] = Config._merge_a_into_b(v, b[k])
+                b[k] = Config._merge_a_into_b(v, b.get(k, ConfigDict()))
             else:
                 if v is None:
                     continue


### PR DESCRIPTION
Resolves an error that appears when passing nested configuration items on the command line.

_Situation_
A nested configuration item is passed on the command line, e.g. `--pipeline.optimizer.lr 0.001`

_Expected_
A `ConfigDict` object is created with nested dictionaries, mirroring an equivalent YAML configuration file (compare [ml3d/configs/randlanet_toronto3d.yml](https://github.com/isl-org/Open3D-ML/blob/master/ml3d/configs/randlanet_toronto3d.yml#L45)):

    pipeline:
        optimizer:
            lr: 0.001

_Actual_
An error is raised:

    TypeError: '<' not supported between instances of 'str' and 'int'

_Analysis_
Nested dictionaries are only merged when the target key already exists in the merge target configuration. This condition does not hold when all configuration items are passed on the command line without using a configuration file.

_Resolution_
Create a default empty `ConfigDict` in the merge target if the corresponding key does not exist.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/493)
<!-- Reviewable:end -->
