### PR TITLE
filter_valid_label: force scores tensor onto the selected device

### DIFF
--- a/ml3d/torch/modules/losses/semseg_loss.py
+++ b/ml3d/torch/modules/losses/semseg_loss.py
@@ -6,7 +6,7 @@ from ....datasets.utils import DataProcessing
 
 def filter_valid_label(scores, labels, num_classes, ignored_label_inds, device):
     """Loss functions for semantic segmentation."""
-    valid_scores = scores.reshape(-1, num_classes)
+    valid_scores = scores.reshape(-1, num_classes).to(device)
     valid_labels = labels.reshape(-1).to(device)
 
     ignored_bool = torch.zeros_like(valid_labels, dtype=torch.bool)


### PR DESCRIPTION
This avoids a crash when calculating semantic segmentation loss during `SemanticSegmentation.run_inference` caused by the `valid_scores` and `valid_labels` tensors existing on separate devices.

This situation only arises when `device` is set to an accelerator, which makes `valid_scores` located on `cpu` and `valid_labels` located on `cuda:0`.

```
INFO - 2022-03-24 14:48:07,015 - train_evaluate - Launching inference for test[0]
Traceback (most recent call last):
  File "train_evaluate.py", line 157, in <module>
    result = pipeline.run_inference(test_instance)
  File "/opt/conda/lib/python3.6/site-packages/open3d/_ml3d/torch/pipelines/semantic_segmentation.py", line 175, in run_inference
    model.cfg.ignored_label_inds, device)
  File "/opt/conda/lib/python3.6/site-packages/open3d/_ml3d/torch/modules/losses/semseg_loss.py", line 20, in filter_valid_label
    valid_idx.unsqueeze(-1).expand(-1, num_classes))
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```