### PR TITLE
Avoid logging.basicConfig in non-scripts

### DIFF
--- a/ml3d/datasets/matterport_objects.py
+++ b/ml3d/datasets/matterport_objects.py
@@ -9,10 +9,6 @@ from .base_dataset import BaseDataset
 from ..utils import DATASET
 from .utils import BEVBox3D
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(levelname)s - %(asctime)s - %(module)s - %(message)s',
-)
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
[matterport_objects.py](https://github.com/isl-org/Open3D-ML/blob/13c847b50f4766cd73f942bd2c12bb86c202c088/ml3d/datasets/matterport_objects.py) calls `logging.basicConfig()`. `basicConfig` is intended for quickly setting up logging in scripts, not for library code. `matterport_objects` is imported by `import open3d` and sets the root log level and format which interferes with logging in the importing code. `matterport_objects` only logs once on initialization and doesn't seem like it should be opinionated about whether that log shows or how it's formatted.

As an example, Bottle's `run(..., quiet=True)` assumes that the root logger's log level stays at the default `WARNING` and `import open3d` sets it to `INFO` via `matterport_objects` which adds a lot of log noise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/open3d-ml/541)
<!-- Reviewable:end -->
