### PR TITLE
Update semantic3d.py

### DIFF
--- a/ml3d/datasets/semantic3d.py
+++ b/ml3d/datasets/semantic3d.py
@@ -235,13 +235,13 @@ class Semantic3DSplit(BaseDatasetSplit):
         feat = np.array(feat, dtype=np.float32)
         intensity = np.array(intensity, dtype=np.float32)
 
-        if (self.split != 'test'):
+        try:
             labels = pd.read_csv(pc_path.replace(".txt", ".labels"),
                                  header=None,
                                  delim_whitespace=True,
                                  dtype=np.int32).values
             labels = np.array(labels, dtype=np.int32).reshape((-1,))
-        else:
+        except FileNotFoundError:
             labels = np.zeros((points.shape[0],), dtype=np.int32)
 
         data = {


### PR DESCRIPTION
If this modification is not made, it means that the labels of test files can't be read. In that case, the code block `if (gt_labels > 0).any():` in `torch/pipelines/semantic_segmentation.py` will be always ignored when executing `pipeline.run_test()`, which causes the skipping of the following metric calculation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D-ML/592)
<!-- Reviewable:end -->
