### PR TITLE
corrected pairing in SSD head of pointpillars

### DIFF
--- a/ml3d/torch/models/point_pillars.py
+++ b/ml3d/torch/models/point_pillars.py
@@ -907,7 +907,7 @@ class Anchor3DHead(nn.Module):
                 # for each anchor the gt with max IoU
                 max_overlaps, argmax_overlaps = overlaps.max(dim=0)
                 # for each gt the anchor with max IoU
-                gt_max_overlaps, _ = overlaps.max(dim=1)
+                gt_max_overlaps, gt_argmax_overlaps = overlaps.max(dim=1)
 
                 pos_idx = max_overlaps >= pos_th
                 neg_idx = (max_overlaps >= 0) & (max_overlaps < neg_th)
@@ -916,6 +916,7 @@ class Anchor3DHead(nn.Module):
                 for k in range(len(target_bboxes[i])):
                     if gt_max_overlaps[k] >= neg_th:
                         pos_idx[overlaps[k, :] == gt_max_overlaps[k]] = True
+                        argmax_overlaps[gt_argmax_overlaps[k]] = k
 
                 # encode bbox for positive matches
                 assigned_bboxes.append(


### PR DESCRIPTION
Accordiing to the PointPillars paper, "A positive match is either the highest with a ground truth box, or above the positive match threshold". While the latter point is implemented correctly, there's a minor mistake in the implementation of the first point. The original code only updates the bool array _pos_idx_ without changing the matched target to the correct ground truth index. This could lead to ground truth box without a valid match in the end.

When I corrected the SSD matching, I also referred to this implementation of SSD: https://github.com/amdegroot/ssd.pytorch/blob/5b0b77faa955c1917b0c710d770739ba8fbff9b7/layers/box_utils.py#L106

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/isl-org/Open3D-ML/602)
<!-- Reviewable:end -->
