### PR TITLE
Update boundingbox.py

### DIFF
--- a/ml3d/vis/boundingbox.py
+++ b/ml3d/vis/boundingbox.py
@@ -245,7 +245,7 @@ class BoundingBox3D:
         if color is None:
             color = np.ones((line_indices.shape[0], line_indices.shape[1], 3))
         for i in range(num_rects):
-            corners = rect_corners[i].astype(np.int_)
+            corners = rect_corners[i].astype(np.int32)
             # ignore boxes outside a certain threshold
             interesting_corners_scale = 3.0
             if min(corners[:, 0]

--- a/ml3d/vis/boundingbox.py
+++ b/ml3d/vis/boundingbox.py
@@ -245,7 +245,7 @@ class BoundingBox3D:
         if color is None:
             color = np.ones((line_indices.shape[0], line_indices.shape[1], 3))
         for i in range(num_rects):
-            corners = rect_corners[i].astype(np.int)
+            corners = rect_corners[i].astype(np.int_)
             # ignore boxes outside a certain threshold
             interesting_corners_scale = 3.0
             if min(corners[:, 0]


### PR DESCRIPTION
changed np.int to np.int_ to make compatible with new versions of numpy where numpy.int is deprecated (>=1.20) or removed (>=1.24). This is compatible back to >=1.13 and possibly earlier (earliest version for which online documentation exists)