### PR TITLE
Update visualizer.py. Fix import when no GUI

### DIFF
--- a/ml3d/vis/visualizer.py
+++ b/ml3d/vis/visualizer.py
@@ -3,6 +3,7 @@ import sys
 import numpy as np
 import threading
 import open3d as o3d
+# Allow Open3D import when visualizer is not built or used.
 if o3d._build_config["BUILD_GUI"]:
     from open3d.visualization import gui
     from open3d.visualization import rendering

--- a/ml3d/vis/visualizer.py
+++ b/ml3d/vis/visualizer.py
@@ -3,8 +3,9 @@ import sys
 import numpy as np
 import threading
 import open3d as o3d
-from open3d.visualization import gui
-from open3d.visualization import rendering
+if o3d._build_config["BUILD_GUI"]:
+    from open3d.visualization import gui
+    from open3d.visualization import rendering
 from collections import deque
 from .boundingbox import *
 from .colormap import *


### PR DESCRIPTION
Shield import when Open3D was not built with GUI.