### PR TITLE
open3d broken with numpy 2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 addict
 pillow>=9.3.0
 matplotlib>=3
-numpy>1.18
+numpy<2
 pandas>=1.0
 pyyaml>=5.4.1
 scikit-learn>=0.21


### PR DESCRIPTION
Numpy version 2 result in a broken install see issue 660 (https://github.com/isl-org/Open3D-ML/issues/660)