### PR TITLE
Fix visualization of unsigned integer attributes

### DIFF
--- a/ml3d/vis/visualizer.py
+++ b/ml3d/vis/visualizer.py
@@ -141,7 +141,7 @@ class Model:
         elif isinstance(ary, np.ndarray):
             if len(ary.shape) == 2 and ary.shape[0] == 1:
                 ary = ary[0]  # "1D" array as 2D: [[1, 2, 3,...]]
-            if ary.dtype.name.startswith('int'):
+            if np.issubdtype(ary.dtype, np.integer):
                 return np.array(ary, dtype='float32')
             else:
                 return ary

--- a/tests/test_visualizer.py
+++ b/tests/test_visualizer.py
@@ -1,0 +1,14 @@
+import numpy as np
+import pytest
+
+from ml3d.vis.visualizer import Model
+
+
+@pytest.mark.parametrize("dtype", [np.uint8, np.uint16, np.uint32, np.uint64])
+def test_unsigned_integer_attributes_are_converted_to_float32(dtype):
+    values = np.array([0, 1, 2], dtype=dtype)
+
+    converted = Model()._convert_to_numpy(values)
+
+    assert converted.dtype == np.float32
+    np.testing.assert_array_equal(converted, values)


### PR DESCRIPTION
## What I found

Issue #671 reports that custom visualization labels stored as `np.uint8` are displayed as class zero, while the same labels work correctly as `np.int64`.

I traced the difference to `Model._convert_to_numpy()`. Its integer check uses `ary.dtype.name.startswith("int")`, which recognizes signed NumPy integer names such as `int64` but not unsigned names such as `uint8`. Unsigned label arrays therefore bypass the `float32` conversion applied to signed labels.

## What I changed

I replaced the dtype-name prefix check with the NumPy semantic integer subtype check:

```python
np.issubdtype(ary.dtype, np.integer)
```

This covers both signed and unsigned NumPy integer types while continuing to exclude floating-point and boolean arrays. The existing flattening and `float32` conversion behavior remains unchanged.

I also added a parameterized regression test covering `uint8`, `uint16`, `uint32`, and `uint64`. It verifies both the resulting `float32` dtype and preservation of the original label values.

## Result

Before the change, all four unsigned integer types remained unsigned after `_convert_to_numpy()`. With the change, they follow the same conversion path as signed integer labels and produce value-preserving `float32` arrays.

## Verification

- `pytest -q tests/test_visualizer.py` — 4 passed
- `python ci/check_style.py --verbose` — passed
- full repository pydocstyle check — passed
- `git diff --check` — passed

Fixes #671.